### PR TITLE
fix: update to support two May 15 UI changes

### DIFF
--- a/grocer/wegmans/targets.py
+++ b/grocer/wegmans/targets.py
@@ -53,7 +53,14 @@ class LoggedInTarget(InstacartTarget):
     def exists(self):
         browser = get_browser(merchant=self.merchant_name)
         # A log out button exists
-        return len(find_by_text(browser, "Log out")) > 0
+        return len(find_by_text(browser, "Log Out")) > 0
+
+
+class TrialPromptClosedTarget(InstacartTarget):
+    def exists(self):
+        browser = get_browser(merchant=self.merchant_name)
+        # The trial prompt is not displayed
+        return len(find_by_text(browser, "Got it, Thanks")) == 0
 
 
 class StoreFrontTarget(InstacartTarget):
@@ -64,7 +71,17 @@ class StoreFrontTarget(InstacartTarget):
         )
 
 
-class DeliveryTimesModalTarget(InstacartTarget):
+class InfoModalTarget(InstacartTarget):
+    def exists(self):
+        browser = get_browser(merchant=self.merchant_name)
+        return (
+            (len(find_by_text(browser, "Info",)) > 0)
+            & (len(find_by_text(browser, "Delivery times",)) > 0)
+            & (len(find_by_text(browser, "Pickup times",)) > 0)
+        )
+
+
+class InfoModalDeliveryTimesTarget(InstacartTarget):
     def exists(self):
         browser = get_browser(merchant=self.merchant_name)
         return len(find_by_text(browser, "Available Scheduled Times",)) > 0

--- a/grocer/wegmans/tasks.py
+++ b/grocer/wegmans/tasks.py
@@ -46,6 +46,12 @@ class LoginPage(Task):
         sleep(5)
 
 
+def close_trial_prompt():
+    buttons = find_by_text(get_browser(merchant=MERCHANT_NAME), "Got it, Thanks",)
+    if len(buttons) > 0:
+        buttons[0].click()
+
+
 @inherits(LoginPage)
 class LoggedIn(Task):
     requires = Requires()
@@ -67,7 +73,9 @@ class LoggedIn(Task):
         buttons = browser.find_elements_by_css_selector("button")
         login_button = buttons[2]
         login_button.click()
-        sleep(15)  # TODO: random delays
+        sleep(28)  # TODO: random delays
+        close_trial_prompt()
+        sleep(5)
 
 
 @inherits(LoggedIn)
@@ -80,6 +88,8 @@ class StoreFront(Task):
         get_browser(merchant=MERCHANT_NAME).get(
             "https://www.instacart.com/store/wegmans/storefront"
         )
+        sleep(29)
+        close_trial_prompt()
         sleep(5)
 
 
@@ -91,10 +101,12 @@ class DeliveryTimesModal(Task):
 
     def run(self):
         cart_button = get_browser(merchant=MERCHANT_NAME).find_element_by_css_selector(
-            'a[href="/wegmans/info?tab=delivery"]'
+            'a[href="/wegmans/info?tab=info"]'
         )
         cart_button.click()
-        sleep(10)
+        sleep(12)
+        find_by_text(get_browser(merchant=MERCHANT_NAME), "Delivery times",)[0].click()
+        sleep(8)
 
 
 # Actions
@@ -115,7 +127,7 @@ class GetDeliveryTimes(Task):
     )
 
     def run(self):
-        # self.detect_load_more_times_button()
+        self.detect_load_more_times_button()
         if self.detect_no_deliveries():
             self.output().write_dask(dd.from_pandas(pd.DataFrame([]), chunksize=1))
         else:

--- a/grocer/wegmans/tasks.py
+++ b/grocer/wegmans/tasks.py
@@ -14,7 +14,9 @@ from .targets import (
     LoginPageTarget,
     LoggedInTarget,
     StoreFrontTarget,
-    DeliveryTimesModalTarget,
+    TrialPromptClosedTarget,
+    InfoModalTarget,
+    InfoModalDeliveryTimesTarget,
 )
 from grocer.utils.browser_utils import get_browser, find_by_text, get_parent
 from grocer.utils.str_utils import is_date, is_time, is_money, get_time_window
@@ -46,12 +48,6 @@ class LoginPage(Task):
         sleep(5)
 
 
-def close_trial_prompt():
-    buttons = find_by_text(get_browser(merchant=MERCHANT_NAME), "Got it, Thanks",)
-    if len(buttons) > 0:
-        buttons[0].click()
-
-
 @inherits(LoginPage)
 class LoggedIn(Task):
     requires = Requires()
@@ -73,9 +69,7 @@ class LoggedIn(Task):
         buttons = browser.find_elements_by_css_selector("button")
         login_button = buttons[2]
         login_button.click()
-        sleep(28)  # TODO: random delays
-        close_trial_prompt()
-        sleep(5)
+        sleep(14)  # TODO: random delays
 
 
 @inherits(LoggedIn)
@@ -88,23 +82,45 @@ class StoreFront(Task):
         get_browser(merchant=MERCHANT_NAME).get(
             "https://www.instacart.com/store/wegmans/storefront"
         )
-        sleep(29)
-        close_trial_prompt()
-        sleep(5)
+        sleep(14)
 
 
 @inherits(StoreFront)
-class DeliveryTimesModal(Task):
+class CloseTrialPrompt(Task):
+    requires = Requires()
+    store_front = Requirement(StoreFront)
+    output = TrialPromptClosedTarget(merchant=MERCHANT_NAME)
+
+    def run(self):
+        buttons = find_by_text(get_browser(merchant=MERCHANT_NAME), "Got it, Thanks",)
+        if len(buttons) > 0:
+            buttons[0].click()
+            sleep(2)
+
+
+@inherits(StoreFront)
+@inherits(CloseTrialPrompt)
+class InfoModal(Task):
     requires = Requires()
     main_page = Requirement(StoreFront)
-    output = DeliveryTimesModalTarget(merchant=MERCHANT_NAME)
+    trial_prompt_closed = Requirement(CloseTrialPrompt)
+    output = InfoModalTarget(merchant=MERCHANT_NAME)
 
     def run(self):
         cart_button = get_browser(merchant=MERCHANT_NAME).find_element_by_css_selector(
             'a[href="/wegmans/info?tab=info"]'
         )
         cart_button.click()
-        sleep(12)
+        sleep(7)
+
+
+@inherits(InfoModal)
+class InfoModalDeliveryTimes(Task):
+    requires = Requires()
+    info_modal = Requirement(InfoModal)
+    output = InfoModalDeliveryTimesTarget(merchant=MERCHANT_NAME)
+
+    def run(self):
         find_by_text(get_browser(merchant=MERCHANT_NAME), "Delivery times",)[0].click()
         sleep(8)
 
@@ -112,10 +128,10 @@ class DeliveryTimesModal(Task):
 # Actions
 
 
-@inherits(DeliveryTimesModal)
+@inherits(InfoModalDeliveryTimes)
 class GetDeliveryTimes(Task):
     requires = Requires()
-    main_page = Requirement(DeliveryTimesModal)
+    main_page = Requirement(InfoModalDeliveryTimes)
 
     # get_time_window() makes sure we don't run this more than once every 5 minutes
     output = TargetOutput(
@@ -127,7 +143,8 @@ class GetDeliveryTimes(Task):
     )
 
     def run(self):
-        self.detect_load_more_times_button()
+        # Commented out because it significantly increases run time
+        # self.detect_load_more_times_button()
         if self.detect_no_deliveries():
             self.output().write_dask(dd.from_pandas(pd.DataFrame([]), chunksize=1))
         else:
@@ -159,7 +176,6 @@ class GetDeliveryTimes(Task):
                 button = get_browser(merchant=MERCHANT_NAME).find_element_by_xpath(
                     '//button[text()="More times"]'
                 )
-                print(button)
                 button.click()
                 sleep(5)
             except NoSuchElementException:


### PR DESCRIPTION
1. Close the Instacart Express upgrade prompt when signing in, if there is one

<img width="415" alt="Screen Shot 2020-05-15 at 8 28 07 PM" src="https://user-images.githubusercontent.com/3478393/82105949-14955280-96ec-11ea-81a1-f5f62f583be8.png">

2. Navigate to the delivery times tab in the info modal

<img width="855" alt="Screen Shot 2020-05-15 at 8 39 24 PM" src="https://user-images.githubusercontent.com/3478393/82105971-30005d80-96ec-11ea-873f-9ceef3e048fb.png">

This used to open directly to the "delivery" tab, but now it opens to the "info" tab and requires an extra button click.

Tested:

```py
$ grocer wegmans times
                   date        time  price
index                                     
0      Saturday, May 16  Noon - 2pm  $5.99
1      Saturday, May 16   1pm - 3pm  $5.99
2      Saturday, May 16   2pm - 4pm  $5.99
3      Saturday, May 16   3pm - 5pm  $5.99
4      Saturday, May 16   4pm - 6pm  $5.99
5      Saturday, May 16   5pm - 7pm  $5.99
```